### PR TITLE
Correct errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Show Parameter block allows the user to alter the alignment of text, update a si
 Kitronik_VIEWTEXT32.showParameter(Kitronik_VIEWTEXT32.ShowAlign.Left, Kitronik_VIEWTEXT32.ShowPage.Single, 1500)
 ```
 
-Scroll Parameter block allows the user to alter the direction of the scroll of text, select the start and finish positions of the scrolling test, select time delay between refresh of screen. THe block needs to be placed before a scroll string block for the changes to take effect:
+Scroll Parameter block allows the user to alter the direction of the scroll of text, select the start and finish positions of the scrolling test, select time delay between refresh of screen. The block needs to be placed before a scroll string block for the changes to take effect:
 ```blocks
 
 Kitronik_VIEWTEXT32.scrollParameter(

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Clear Display Line block will clear what is currently displayed on the selected 
 Kitronik_VIEWTEXT32.clearDisplayLine(Kitronik_VIEWTEXT32.DisplayLine.Top)
 ```
 
-Show Parameter block allows the user to alter the alignment of text, update a single line or double lines of the screen, select time delay between refresh of screen. THe block needs to be placed before a show string block for the changes to take effect:
+Show Parameter block allows the user to alter the alignment of text, update a single line or double lines of the screen, select time delay between refresh of screen. The block needs to be placed before a show string block for the changes to take effect:
 ```blocks
 Kitronik_VIEWTEXT32.showParameter(Kitronik_VIEWTEXT32.ShowAlign.Left, Kitronik_VIEWTEXT32.ShowPage.Single, 1500)
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Kitronik_VIEWTEXT32.ScrollPosition.Off,
 
 Emjoicon block gives a list of emojis that can be added into a string of text using join text or displayed on their own:
 ```blocks
-Kitronik_VIEWTEXT32.displayEmjoicon(Kitronik_VIEWTEXT32.Emoticon.Happy)
+let myString = "Hello" + Kitronik_VIEWTEXT32.displayEmjoicon(Kitronik_VIEWTEXT32.Emoticon.Happy)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Kitronik blocks for micro:bit
 
 Blocks that support [Kitronik kits and shields for the micro:bit](https://www.kitronik.co.uk/microbit.html)
-This package is for the [Kitronik :VIEW Text32]
+This package is for the [Kitronik :VIEW Text32](https://kitronik.co.uk/5650).
 
 Show String block will show the inserted string and automatically update the screen if string is more than 32 charectors:
 ```blocks

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Blocks that support [Kitronik kits and shields for the micro:bit](https://www.kitronik.co.uk/microbit.html)
 This package is for the [Kitronik :VIEW Text32](https://kitronik.co.uk/5650).
 
-Show String block will show the inserted string and automatically update the screen if string is more than 32 charectors:
+Show String block will show the inserted string and automatically update the screen if string is more than 32 characters:
 ```blocks
 Kitronik_VIEWTEXT32.showString("Hello!")
 ```


### PR DESCRIPTION
* add missing link to Kitronik :VIEW text32 product
* correct some spelling mistakes
* correct a badly rendered block (see the last block in https://makecode.microbit.org/pkg/KitronikLtd/pxt-kitronik-viewtext32) 
![image](https://user-images.githubusercontent.com/54072413/108854145-482fd200-75c6-11eb-9d91-48701c3a1330.png)
